### PR TITLE
Move unittests to tests/

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,4 +30,4 @@ jobs:
           jupyter kernelspec list
 
       - name: Execute tests
-        run: make test
+        run: pytest tests/

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,0 @@
-test:
-	pytest tests/ scripts/*.py

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # nmaci
+[![CI](https://github.com/neuromatch/nmaci/actions/workflows/ci.yaml/badge.svg)](https://github.com/neuromatch/nmaci/actions/workflows/ci.yaml)
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -442,19 +442,6 @@ def clean_whitespace(nb):
             cell["source"] = "\n".join(clean_lines)
 
 
-def test_clean_whitespace():
-
-    nb = {
-        "cells": [
-            {"cell_type": "code", "source": "import numpy  \nimport matplotlib   "},
-            {"cell_type": "markdown", "source": "# Test notebook  "},
-        ]
-    }
-    clean_whitespace(nb)
-    assert nb["cells"][0]["source"] == "import numpy\nimport matplotlib"
-    assert nb["cells"][1]["source"] == "# Test notebook  "
-
-
 def has_solution(cell):
     """Return True if cell is marked as containing an exercise solution."""
     cell_text = cell["source"].replace(" ", "").lower()
@@ -475,35 +462,9 @@ def has_code_exercise(cell):
     )
 
 
-def test_has_solution():
-
-    cell = {"source": "# solution"}
-    assert not has_solution(cell)
-
-    cell = {"source": "def exercise():\n    pass\n# to_remove"}
-    assert not has_solution(cell)
-
-    cell = {"source": "# to_remove_solution\ndef exercise():\n    pass"}
-    assert has_solution(cell)
-
-
 def has_colab_badge(cell):
     """Return True if cell has a Colab badge as an HTML element."""
     return "colab-badge.svg" in cell["source"]
-
-
-def test_has_colab_badge():
-
-    cell = {
-        "source": "import numpy as np"
-    }
-    assert not has_colab_badge(cell)
-
-    cell = {
-        "source":
-        "<img src=\"https://colab.research.google.com/assets/colab-badge.svg\" "
-    }
-    assert has_colab_badge(cell)
 
 
 def redirect_colab_badge_to_main_branch(cell):
@@ -511,25 +472,6 @@ def redirect_colab_badge_to_main_branch(cell):
     cell_text = cell["source"]
     p = re.compile(r"^(.+/" + ORG + "/" + REPO + r"/blob/)[\w-]+(/.+$)")
     cell["source"] = p.sub(r"\1" + MAIN_BRANCH + r"\2", cell_text)
-
-
-def test_redirect_colab_badge_to_main_branch():
-
-    original = (
-        f"\"https://colab.research.google.com/github/{ORG}/"
-        "course-content/blob/W1D1-updates/tutorials/W1D1_ModelTypes/"
-        "W1D1_Tutorial1.ipynb\""
-    )
-    cell = {"source": original}
-    redirect_colab_badge_to_main_branch(cell)
-
-    expected = (
-        f"\"https://colab.research.google.com/github/{ORG}/"
-        "course-content/blob/main/tutorials/W1D1_ModelTypes/"
-        "W1D1_Tutorial1.ipynb\""
-    )
-
-    assert cell["source"] == expected
 
 
 def redirect_colab_badge_to_student_version(cell):
@@ -553,25 +495,6 @@ def redirect_colab_badge_to_instructor_version(cell):
     p = re.compile(r"(^.+/tutorials/W\dD\d\w+)/(\w+\.ipynb.+)")
     cell["source"] = p.sub(r"\1/instructor/\2", cell_text)
 
-
-def test_redirect_colab_badge_to_student_version():
-
-    original = (
-        f"\"https://colab.research.google.com/github/{ORG}/"
-        "course-content/blob/main/tutorials/W1D1_ModelTypes/"
-        "W1D1_Tutorial1.ipynb\""
-    )
-
-    cell = {"source": original}
-    redirect_colab_badge_to_student_version(cell)
-
-    expected = (
-        f"\"https://colab.research.google.com/github/{ORG}/"
-        "course-content/blob/main/tutorials/W1D1_ModelTypes/student/"
-        "W1D1_Tutorial1.ipynb\""
-    )
-
-    assert cell["source"] == expected
 
 def add_kaggle_badge(cell, nb_path):
     """Add a kaggle badge if not exists."""

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -49,8 +49,8 @@ class LoggingExecutePreprocessor(ExecutePreprocessor):
     """ExecutePreprocessor that logs cell-by-cell progress."""
 
     def preprocess_cell(self, cell, resources, index):
-        if cell.cell_type == 'code' and cell.source.strip():
-            code_preview = cell.source.strip().split('\n')[0][:80]
+        if cell.cell_type == "code" and cell.source.strip():
+            code_preview = cell.source.strip().split("\n")[0][:80]
             print(f"[Cell {index + 1}] {code_preview}")
             sys.stdout.flush()
             start = time.time()
@@ -455,29 +455,6 @@ def has_code_exercise(cell):
     return cell_text.startswith("#@titlesolution") or "to_removesolution" in first_line
 
 
-<<<<<<< HEAD
-def has_colab_badge(cell):
-    """Return True if cell has a Colab badge as an HTML element."""
-    return "colab-badge.svg" in cell["source"]
-
-
-def redirect_colab_badge_to_main_branch(cell):
-    """Modify the Colab badge to point at the main branch on Github."""
-    cell_text = cell["source"]
-    p = re.compile(r"^(.+/" + ORG + "/" + REPO + r"/blob/)[\w-]+(/.+$)")
-    cell["source"] = p.sub(r"\1" + MAIN_BRANCH + r"\2", cell_text)
-
-
-def redirect_colab_badge_to_student_version(cell):
-    """Modify the Colab badge to point at student version of the notebook."""
-    cell_text = cell["source"]
-    # redirect the colab badge
-    p = re.compile(r"(^.+blob/" + MAIN_BRANCH + r"/tutorials/W\dD\d\w+)/(\w+\.ipynb.+)")
-    cell_text = p.sub(r"\1/student/\2", cell_text)
-    # redirect the kaggle badge
-    p = re.compile(r"(^.+/tutorials/W\dD\d\w+)/(\w+\.ipynb.+)")
-    cell["source"] = p.sub(r"\1/student/\2", cell_text)
-=======
 def test_has_solution():
 
     cell = {"source": "# solution"}
@@ -561,7 +538,6 @@ def generate_badge_cell(nb_path: Path | str) -> dict:
 
 def add_badge_cell(nb: dict, nb_path: dict | str) -> None:
     """Remove existing badges and add a new badge cell at the top of the notebook.
->>>>>>> main
 
     Args:
         nb: The notebook dict
@@ -571,30 +547,6 @@ def add_badge_cell(nb: dict, nb_path: dict | str) -> None:
     badge_cell = generate_badge_cell(nb_path)
     nb["cells"].insert(0, badge_cell)
 
-<<<<<<< HEAD
-def redirect_colab_badge_to_instructor_version(cell):
-    """Modify the Colab badge to point at instructor version of the notebook."""
-    cell_text = cell["source"]
-    # redirect the colab badge
-    p = re.compile(r"(^.+blob/" + MAIN_BRANCH + r"/tutorials/W\dD\d\w+)/(\w+\.ipynb.+)")
-    cell_text = p.sub(r"\1/instructor/\2", cell_text)
-    # redirect the kaggle badge
-    p = re.compile(r"(^.+/tutorials/W\dD\d\w+)/(\w+\.ipynb.+)")
-    cell["source"] = p.sub(r"\1/instructor/\2", cell_text)
-
-
-def add_kaggle_badge(cell, nb_path):
-    """Add a kaggle badge if not exists."""
-    cell_text = cell["source"]
-    if "kaggle" not in cell_text:
-        badge_link = "https://kaggle.com/static/images/open-in-kaggle.svg"
-        service = "https://kaggle.com/kernels/welcome?src="
-        alter = "Open in Kaggle"
-        basic_url = f"https://raw.githubusercontent.com/{ORG}"
-        a = f'<a href=\"{service}{basic_url}/{REPO}/{MAIN_BRANCH}/{nb_path}\" target=\"_parent\"><img src=\"{badge_link}\" alt=\"{alter}\"/></a>'
-        cell["source"] += f' &nbsp; {a}'
-=======
->>>>>>> main
 
 def sequentially_executed(nb):
     """Return True if notebook appears freshly executed from top-to-bottom."""

--- a/tests/test_process_notebooks.py
+++ b/tests/test_process_notebooks.py
@@ -8,6 +8,7 @@ from scripts.process_notebooks import (
     generate_badge_cell,
     remove_existing_badges,
     clean_whitespace,
+    has_solution,
 )
 
 
@@ -100,59 +101,7 @@ def test_has_solution():
     assert has_solution(cell)
 
 
-def test_has_colab_badge():
-
-    cell = {"source": "import numpy as np"}
-    assert not has_colab_badge(cell)
-
-    cell = {
-        "source": '<img src="https://colab.research.google.com/assets/colab-badge.svg" '
-    }
-    assert has_colab_badge(cell)
-
-
-def test_redirect_colab_badge_to_main_branch():
-
-    original = (
-        f'"https://colab.research.google.com/github/{ORG}/'
-        f"{REPO}/blob/W1D1-updates/tutorials/W1D1_ModelTypes/"
-        'W1D1_Tutorial1.ipynb"'
-    )
-    cell = {"source": original}
-    redirect_colab_badge_to_main_branch(cell)
-
-    expected = (
-        f'"https://colab.research.google.com/github/{ORG}/'
-        f"{REPO}/blob/{MAIN_BRANCH}/tutorials/W1D1_ModelTypes/"
-        'W1D1_Tutorial1.ipynb"'
-    )
-
-    assert cell["source"] == expected
-
-
-def test_redirect_colab_badge_to_student_version():
-
-    original = (
-        f'"https://colab.research.google.com/github/{ORG}/'
-        f"{REPO}/blob/{MAIN_BRANCH}/tutorials/W1D1_ModelTypes/"
-        'W1D1_Tutorial1.ipynb"'
-    )
-
-    cell = {"source": original}
-    redirect_colab_badge_to_student_version(cell)
-
-    expected = (
-        f'"https://colab.research.google.com/github/{ORG}/'
-        f"{REPO}/blob/{MAIN_BRANCH}/tutorials/W1D1_ModelTypes/student/"
-        'W1D1_Tutorial1.ipynb"'
-    )
-
-    assert cell["source"] == expected
-
-
 # --- Badge function tests ---
-
-
 def test_remove_existing_badges_colab_only():
     """Test removing a cell with only a Colab badge."""
     nb = {

--- a/tutorials/raises_name_error.ipynb
+++ b/tutorials/raises_name_error.ipynb
@@ -13,9 +13,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "nma (py37)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "nma"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/raises_notimplemented_error.ipynb
+++ b/tutorials/raises_notimplemented_error.ipynb
@@ -35,9 +35,9 @@
    "name": "python3"
   },
   "kernelspec": {
-   "display_name": "nma (py37)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "nma"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
I moved the test functions that were in scripts/process-notebooks.py to the tests/ folder and fixed the broken test test_redirect_colab_badge_to_main_branch.

I also removed the Makefile and moved the pytest call to ci.yaml to remove the unnecessary indirection and added a tests passing badge to the README.